### PR TITLE
types: add types for retry behaviour on failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,11 @@ interface Options<T extends Payload> extends RequestInit {
     response: Response,
     options: Options<T>
   ): Response | Promise<Response>
-  /** Error handler, must throw an `Error` */
+  /** Error handler, must throw an `Error` or retry response with `request` */
   onFailure?(
-    error: ResponseError | AbortError | TimeoutError | Error,
+    error: ResponseError | AbortError | TimeoutError | TypeError | Error,
     options: Options<T>
-  ): never | Promise<never>
+  ): never | Promise<never> | Promise<Response>
   /** Transform parsed JSON from response */
   onJSON?(input: unknown): unknown
 }


### PR DESCRIPTION
## Context

When the `fetch` call fails, the function `onFailure` will be called, with the error `TypeError`. In this situation, if the developer would like to retry the call (using `request`), we need to update the type response of it as well.

To reproduce the issue please check this codepen --> https://codepen.io/EmaSuriano/pen/WNEjxBX?editors=0012